### PR TITLE
Alts 472 cdp pal compute service get stale

### DIFF
--- a/cdp-pal/cdp-pal/cdp-pal-common/pom.xml
+++ b/cdp-pal/cdp-pal/cdp-pal-common/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>com.att.cdp</groupId>
     <artifactId>cdp-pal</artifactId>
-    <version>1.1.25.13-SNAPSHOT</version>
+    <version>1.1.25.9-oss</version>
   </parent>
 
   <artifactId>cdp-pal-common</artifactId>
   <name>CDP - PAL common code</name>
-  <version>1.1.25.13-SNAPSHOT</version>
+  <version>1.1.25.9-oss</version>
   <description>Cloud Deployment Platform</description>
   <url>https://github.com/att/AJSC/tree/master/cdp-pal</url>
   

--- a/cdp-pal/cdp-pal/cdp-pal-common/pom.xml
+++ b/cdp-pal/cdp-pal/cdp-pal-common/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <artifactId>cdp-pal-common</artifactId>
-  <name>CDP - PAL common code</name>
+  <name> CDP - PAL common code </name>
   <version>1.1.25.9-oss</version>
   <description>Cloud Deployment Platform</description>
   <url>https://github.com/att/AJSC/tree/master/cdp-pal</url>

--- a/cdp-pal/cdp-pal/cdp-pal-openstack/pom.xml
+++ b/cdp-pal/cdp-pal/cdp-pal-openstack/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>com.att.cdp</groupId>
 		<artifactId>cdp-pal</artifactId>
-		<version>1.1.25.13-SNAPSHOT</version>
+		<version>1.1.25.9-oss</version>
 	</parent>
 
 	<artifactId>cdp-pal-openstack</artifactId>
 	<name>CDP - PAL Openstack implementation</name>
-	<version>1.1.25.13-SNAPSHOT</version>
+	<version>1.1.25.9-oss</version>
 	<description>Cloud Delivery Platform </description>
 	<packaging>jar</packaging>
 	<url>https://github.com/att/AJSC/tree/master/cdp-pal</url>

--- a/cdp-pal/cdp-pal/pom.xml
+++ b/cdp-pal/cdp-pal/pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
   <name>CDP - Provider Abstraction Layer</name>
   <description>Cloud Deployment Platform</description>
-  <version>1.1.25.13-SNAPSHOT</version>
+  <version>1.1.25.9-oss</version>
   <url>https://github.com/att/AJSC/tree/master/cdp-pal</url>
 
   <!-- ================================================================================== -->


### PR DESCRIPTION
Changed the version to 1.1.25.9-oss. This version contains lots of log statements for the debugging purpose.