### PR TITLE
[ALTS-472] Added catch for ProcessingException and throwing TimeOutExce

### DIFF
--- a/cdp-pal/cdp-pal/cdp-pal-common/pom.xml
+++ b/cdp-pal/cdp-pal/cdp-pal-common/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>com.att.cdp</groupId>
     <artifactId>cdp-pal</artifactId>
-    <version>1.1.25.11-oss</version>
+    <version>1.1.25.12-oss</version>
   </parent>
 
   <artifactId>cdp-pal-common</artifactId>
   <name> CDP - PAL common code </name>
-  <version>1.1.25.11-oss</version>
+  <version>1.1.25.12-oss</version>
   <description>Cloud Deployment Platform</description>
   <url>https://github.com/att/AJSC/tree/master/cdp-pal</url>
   
@@ -105,6 +105,11 @@
       <artifactId>jsch</artifactId>
       <version>0.1.51</version>
     </dependency>
+    <dependency>
+		<groupId>javax.ws.rs</groupId>
+		<artifactId>javax.ws.rs-api</artifactId>
+		<version>2.0.1</version>
+	</dependency>
 
   </dependencies>
   

--- a/cdp-pal/cdp-pal/cdp-pal-openstack/pom.xml
+++ b/cdp-pal/cdp-pal/cdp-pal-openstack/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>com.att.cdp</groupId>
 		<artifactId>cdp-pal</artifactId>
-		<version>1.1.25.11-oss</version>
+		<version>1.1.25.12-oss</version>
 	</parent>
 
 	<artifactId>cdp-pal-openstack</artifactId>
 	<name>CDP - PAL Openstack implementation</name>
-	<version>1.1.25.11-oss</version>
+	<version>1.1.25.12-oss</version>
 	<description>Cloud Delivery Platform </description>
 	<packaging>jar</packaging>
 	<url>https://github.com/att/AJSC/tree/master/cdp-pal</url>

--- a/cdp-pal/cdp-pal/cdp-pal-openstack/src/main/java/com/att/cdp/openstack/ServiceCatalog.java
+++ b/cdp-pal/cdp-pal/cdp-pal-openstack/src/main/java/com/att/cdp/openstack/ServiceCatalog.java
@@ -664,7 +664,10 @@ public class ServiceCatalog {
             RequestConfig.Builder builder = RequestConfig.custom();
             builder.setConnectionRequestTimeout(30000);
             builder.setConnectTimeout(30000);
-            builder.setRedirectsEnabled(true);
+            
+            builder.setSocketTimeout(120000); 
+         
+            builder.setRedirectsEnabled(true); 
             RequestConfig rc = builder.build();
 
             HttpGet request = new HttpGet();

--- a/cdp-pal/cdp-pal/pom.xml
+++ b/cdp-pal/cdp-pal/pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
   <name>CDP - Provider Abstraction Layer</name>
   <description>Cloud Deployment Platform</description>
-  <version>1.1.25.11-oss</version>
+  <version>1.1.25.12-oss</version>
   <url>https://github.com/att/AJSC/tree/master/cdp-pal</url>
 
   <!-- ================================================================================== -->
@@ -253,6 +253,11 @@
 	    <artifactId>jackson-jaxrs-json-provider</artifactId>
 	    <version>2.8.8</version>
 	 </dependency>
+	 <dependency>
+		<groupId>javax.ws.rs</groupId>
+		<artifactId>javax.ws.rs-api</artifactId>
+		<version>2.0.1</version>
+	</dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Adding conversation I had with Trupti:

Trupti Savant(10:05:03 AM): If I set 300 sec on each http request then total timeout will 300* total retries, isn't it?
Trupti Savant(10:06:39 AM): sorry, it will not be.. then there will not any retries
Shailendra(10:08:43 AM): I think the whole idea is that the timeout for entire operation is 300 seconds, hence the outer loop timeout of 300 seconds
Shailendra(10:09:16 AM): ideally the connection and http get should not take any time at all
Shailendra(10:09:36 AM): hence we need to set up a reasonable http timeout like 120 seconds.
Shailendra(10:14:49 AM): OpenstackContext has retrylimit and retrydelay but no timeout.
Shailendra(10:15:12 AM): just like 30 seconds is hardcoded, you can use 120 seconds
Trupti Savant(10:33:49 AM): okay then

Reading descriptions of the multiple defects in Migrate and Evacuate Server, there seem to be multiple issues:
1. CDP-PAL not catching ProcessingException.  As of now, I see that CDP-PAL waitForStateChange throws following excepions:  TimeoutException, NotNavigableException, InvalidRequestException, ContextClosedException, ZoneException.  These are thrown at lower level code. It does not list ProcessingException. For this CDP-PAL code should be modified to catch the exception ProcessingException and throw a TimeoutException.


 